### PR TITLE
Potential fixes to type hierarchy

### DIFF
--- a/src/DataTypes.jl
+++ b/src/DataTypes.jl
@@ -1,9 +1,60 @@
+"""
+    AbstractThings
 
+Supertype for container of objects being observed, whether these are
+species, sequences, tips of a phylogeny (which could be either), or
+some other type of thing. This will contain the names of the things
+being observed, and (optionally) metadata about them, such as a
+phylogeny that connects them, taxonomic information, their sequences,
+trait information, information on similarity between the different
+things, etc.
 
+"""
 abstract type AbstractThings end
+
+"""
+    AbstractPlaces
+
+Supertype for container of places where things are found (see
+AbstractThings). This will contain names or a reference for the
+places, and (optionally) metadata such as what kind of place these
+are, e.g. geographic locations (see subtype AbstractLocations), where
+additional metadata will includes location data, animal ids for where
+the samples of things where retrieved from, etc.
+
+"""
 abstract type AbstractPlaces end
+
+"""
+    AbstractLocations <: AbstractPlaces
+
+Subtype of AbstractPlaces that refers to locations with some
+geographical component. This may be a series of arbitrarily arranged
+points, a series of areas, or even grid of of regularly spaced
+quadrats (see AbstractGrid).
+
+"""
 abstract type AbstractLocations <: AbstractPlaces end
+
+"""
+    AbstractGrid <: AbstractLocations <: AbstractPlaces
+
+Subtype of AbstractLocations that refers to a grid of regularly
+spaced, identically shaped, locations.
+"""
 abstract type AbstractGrid <: AbstractLocations end
+
+"""
+    AbstractAssemblage{T <: AbstractThings,
+                       P <: AbstractPlaces,
+                       D <: Real (e.g. Int, Float64, Bool)}
+
+An assemblage of things recorded as being present in one or more
+places. These may, for instance, be species counts in quadrats over a
+regular grid, relative abundance of viral sequences in a group of
+individuals, or presence-absence of genera over multiple islands.
+
+"""
 abstract type AbstractAssemblage{T <: AbstractThings,
                                  P <: AbstractPlaces,
                                  D <: Real}

--- a/src/DataTypes.jl
+++ b/src/DataTypes.jl
@@ -1,9 +1,11 @@
 
-# depend explicitly on AxisArrays (sparse) in some implementation?
 
 abstract type AbstractThings end
 abstract type AbstractPlaces end
-abstract type AbstractGrid <: AbstractPlaces end
-abstract type AbstractPoints <: AbstractPlaces end
-abstract type AbstractAssemblage{T <: AbstractThings, P <: AbstractPlaces} <: AbstractTemporalAssemblage end
-abstract type AbstractTemporalAssemblage end 
+abstract type AbstractLocations <: AbstractPlaces end
+abstract type AbstractGrid <: AbstractLocations end
+abstract type AbstractAssemblage{T <: AbstractThings,
+                                 P <: AbstractPlaces,
+                                 D <: Real}
+
+# depend explicitly on AxisArrays (and/or sparse) in some implementation?

--- a/src/DataTypes.jl
+++ b/src/DataTypes.jl
@@ -57,6 +57,6 @@ individuals, or presence-absence of genera over multiple islands.
 """
 abstract type AbstractAssemblage{T <: AbstractThings,
                                  P <: AbstractPlaces,
-                                 D <: Real}
+                                 D <: Real} end
 
 # depend explicitly on AxisArrays (and/or sparse) in some implementation?

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -1,38 +1,36 @@
-
-
-# Functions
-occurrences(com::AbstractAssemblage) = error("function not defined for this type") #has to be implemented with the concrete type
-thingnames(com::AbstractAssemblage) = error("function not defined for this type")
+# Functions - most have to be implemented with the concrete type
+occurrences(com::AbstractAssemblage) = error("function not defined for this type") 
 view(com::AbstractAssemblage) = error("function not defined for this type")
 places(asm::AbstractAssemblage) = error("function not defined for this type")
 things(asm::AbstractAssemblage) = error("function not defined for this type")
-nplaces(asm::AbstractPlaces) = error("function not defined for this type")
+
+nplaces(com::AbstractPlaces) = size(occurrences(com), 2)
 placenames(com::AbstractPlaces) = error("function not defined for this type")
 
-nzrows(a::AbstractMatrix) = find(sum(a .> 0, 2)> 0)
-nzcols(a::AbstractMatrix) = find(sum(a .> 0, 1)> 0)
+nthings(com::AbstractThings) = size(occurrences(com), 1)
+thingnames(com::AbstractThings) = error("function not defined for this type")
+
+nzrows(a::AbstractMatrix) = find(sum(a .> 0, 2) > 0)
+nzcols(a::AbstractMatrix) = find(sum(a .> 0, 1) > 0)
 
 occurring(com::AbstractAssemblage) = nzrows(occurrences(com))
 occupied(com::AbstractAssemblage) = nzcols(occurrences(com))
-occupied(com::AbstractAssemblage, idx) = findn(occurrences(com)[idx,:])
-occurring(com::AbstractAssemblage, idx) = findn(occurrences(com)[:,idx])
+occupied(com::AbstractAssemblage, idx) = findn(occurrences(com)[idx, :])
+occurring(com::AbstractAssemblage, idx) = findn(occurrences(com)[:, idx])
 
 noccurring(x) = length(occurring(x))
 noccupied(x) = length(occupied(x))
 noccurring(x, idx) = length(occurring(x, idx))
 noccupied(x, idx) = length(occupied(x, idx))
 
-nthings(com::AbstractThings) = size(occurrences(com), 1)
-nplaces(com::AbstractPlaces) = size(occurrences(com), 2)
-
 thingoccurrences(com::AbstractAssemblage, idx) = view(occurrences(com), idx, :)
 placeoccurrences(com::AbstractAssemblage, idx) = view(occurrences(com), :, idx) # make certain that the view implementation also takes thing or place names
 
-richness(com::AbstractAssemblage{Bool}) = vec(sum(occurrences(com), 1))
-richness(com::AbstractAssemblage{<:Real}) = vec(mapslices(nnz, occurrences(com), 1))
+richness(com::AbstractAssemblage{_, _, Bool}) = vec(sum(occurrences(com), 1))
+richness(com::AbstractAssemblage) = vec(mapslices(nnz, occurrences(com), 1))
 
-occupancy(com::AbstractAssemblage{Bool}) = vec(sum(occurrences(com), 2))
-occupancy(com::AbstractAssemblage{<:Real}) = vec(mapslices(nnz, occurrences(com), 2))
+occupancy(com::AbstractAssemblage{_, _, Bool}) = vec(sum(occurrences(com), 2))
+occupancy(com::AbstractAssemblage) = vec(mapslices(nnz, occurrences(com), 2))
 
 records(com::AbstractAssemblage) = nnz(occurrences(com))
 
@@ -42,15 +40,15 @@ function cooccurring(com::AbstractAssemblage, inds::AbstractVector)
     richness(sub) .== nthings(sub)
 end
 
-function createsummaryline(vec::AbstractVector{T}) where T<:AbstractString
-    linefunc(vec) = mapreduce(x->x*", ", *, vec[1:(end-1)])*vec[end]
+function createsummaryline(vec::AbstractVector{T}) where T <: AbstractString
+    linefunc(vec) = mapreduce(x->x * ", ", *, vec[1:(end-1)]) * vec[end]
     length(vec) == 1 && return vec[1]
     length(vec) < 6 && return linefunc(vec)
-    linefunc(vec[1:3])*"..."*linefunc(vec[(end-1):end])
+    linefunc(vec[1:3]) * "..." * linefunc(vec[(end-1):end])
 end
 
 
-function show(io::IO, com::T) where T <:AbstractAssemblage
+function show(io::IO, com::T) where T <: AbstractAssemblage
     sp = createsummaryline(thingnames(com))
     si = createsummaryline(placenames(com))
     println(io, "$T with $(nthings(com)) things in $(nplaces(com)) places\n\nThing names:\n$(sp)\n\nPlace names:\n$(si)")
@@ -60,7 +58,7 @@ end
 macro forward_func(ex, fs)
     T, field = ex.args[1], ex.args[2].args[1]
     T = esc(T)
-    fs = isexpr(fs, :tuple) ? map(esc, fs.args) : [esc(fs)]
+    fs = Meta.isexpr(fs, :tuple) ? map(esc, fs.args) : [esc(fs)]
     :($([:($f(x::$T, args...) = (Base.@_inline_meta; $f($(field)(x), args...)))
         for f in fs]...);
     nothing)

--- a/src/Interface.jl
+++ b/src/Interface.jl
@@ -26,10 +26,10 @@ noccupied(x, idx) = length(occupied(x, idx))
 thingoccurrences(com::AbstractAssemblage, idx) = view(occurrences(com), idx, :)
 placeoccurrences(com::AbstractAssemblage, idx) = view(occurrences(com), :, idx) # make certain that the view implementation also takes thing or place names
 
-richness(com::AbstractAssemblage{_, _, Bool}) = vec(sum(occurrences(com), 1))
+richness(com::AbstractAssemblage{T, P, Bool}) where {T, P} = vec(sum(occurrences(com), 1))
 richness(com::AbstractAssemblage) = vec(mapslices(nnz, occurrences(com), 1))
 
-occupancy(com::AbstractAssemblage{_, _, Bool}) = vec(sum(occurrences(com), 2))
+occupancy(com::AbstractAssemblage{T, P, Bool}) where {T, P} = vec(sum(occurrences(com), 2))
 occupancy(com::AbstractAssemblage) = vec(mapslices(nnz, occurrences(com), 2))
 
 records(com::AbstractAssemblage) = nnz(occurrences(com))
@@ -41,10 +41,10 @@ function cooccurring(com::AbstractAssemblage, inds::AbstractVector)
 end
 
 function createsummaryline(vec::AbstractVector{T}) where T <: AbstractString
-    linefunc(vec) = mapreduce(x->x * ", ", *, vec[1:(end-1)]) * vec[end]
+    linefunc(vec) = mapreduce(x->x*", ", *, vec[1:(end-1)])*vec[end]
     length(vec) == 1 && return vec[1]
     length(vec) < 6 && return linefunc(vec)
-    linefunc(vec[1:3]) * "..." * linefunc(vec[(end-1):end])
+    linefunc(vec[1:3])*"..."*linefunc(vec[(end-1):end])
 end
 
 
@@ -67,7 +67,7 @@ end
 @forward_func AbstractAssemblage.places nplaces, placenames
 @forward_func AbstractAssemblage.things nthings, thingnames
 
-TODO:
+# TODO:
 # accessing cache
 
 
@@ -81,8 +81,8 @@ cellsize(g::AbstractGrid) = xcellsize(g), ycellsize(g)
 cells(g::AbstractGrid) = xcells(g), ycells(g)
 xrange(g::AbstractGrid) = xmin(g):xcellsize(g):xmax(g) #includes intermediary points
 yrange(g::AbstractGrid) = ymin(g):ycellsize(g):ymax(g)
-xmax(g::AbstractGrid) = xmin(g) + xcellsize(g) * (xcells(g)-1)
-ymax(g::AbstractGrid) = ymin(g) + ycellsize(g) * (ycells(g)-1)
+xmax(g::AbstractGrid) = xmin(g) + xcellsize(g)*(xcells(g)-1)
+ymax(g::AbstractGrid) = ymin(g) + ycellsize(g)*(ycells(g)-1)
 
 
 indices(grd::AbstractGrid, idx) = error("function not defined for this type") #Implement this in SpatialEcology!

--- a/src/PlotRecipes.jl
+++ b/src/PlotRecipes.jl
@@ -16,11 +16,11 @@ RecipesBase.@recipe function f(var::AbstractVector, grd::AbstractGrid)
     xrange(grd), yrange(grd), convert_to_image(var, grd)
 end
 
-RecipesBase.@recipe function f(sit::SiteFields)
-    ones(nsites(sit)), sit
-end
+# RecipesBase.@recipe function f(sit::SiteFields) # not sure what SiteFields are
+#     ones(nsites(sit)), sit
+# end
 
-RecipesBase.@recipe function f(var::AbstractVector, pnt::AbstractPoints)
+RecipesBase.@recipe function f(var::AbstractVector, pnt::AbstractLocations)
     registercolors()
     seriestype := :scatter
     aspect_ratio --> :equal


### PR DESCRIPTION
@mkborregaard I'm not sure the hierarchy was ideal as it was. Apart from some small errors, and the fact that there is some temporal stuff still in there, there were some unnecessary abstract types - AbstractGrid can be a subtype of AbstractLocations (replacing AbstractPoints), and then AbstractPlaces can have spatial locations or (e.g.) individual names, AbstractLocations can be points, areas or regular points or areas, and AbstractGrid is then specifically regular points or areas. AbstractLocations is better than AbstractPoints because these can be points or areas - we need to setters/getters for that too I guess...